### PR TITLE
JQuery dependency and backbone view

### DIFF
--- a/jupyter_notebook/static/notebook/js/codecell.js
+++ b/jupyter_notebook/static/notebook/js/codecell.js
@@ -231,7 +231,7 @@ define([
         var that = this;
         return view_promise.then(function(view) {
             that.widget_area.show();
-            dummy.replaceWith(view.$el);
+            dummy.replaceWith(view.el);
             that.widget_views.push(view);
 
             // Check the live state of the view's model.

--- a/jupyter_notebook/static/notebook/js/keyboardmanager.js
+++ b/jupyter_notebook/static/notebook/js/keyboardmanager.js
@@ -188,6 +188,7 @@ define([
     };
 
     KeyboardManager.prototype.register_events = function (e) {
+        e = $(e);
         var that = this;
         var handle_focus = function () {
             that.disable();

--- a/jupyter_notebook/static/widgets/js/manager.js
+++ b/jupyter_notebook/static/widgets/js/manager.js
@@ -162,7 +162,7 @@ define([
          * Note, this is only done on the outer most widgets.
          */
         if (this.keyboard_manager) {
-            this.keyboard_manager.register_events(view.$el);
+            this.keyboard_manager.register_events(view.el);
         
             if (view.additional_elements) {
                 for (var i = 0; i < view.additional_elements.length; i++) {

--- a/jupyter_notebook/static/widgets/js/manager.js
+++ b/jupyter_notebook/static/widgets/js/manager.js
@@ -4,11 +4,10 @@
 define([
     "underscore",
     "backbone",
-    "jquery",
     "base/js/utils",
     "base/js/namespace",
     "services/kernels/comm"
-], function (_, Backbone, $, utils, IPython, comm) {
+], function (_, Backbone, utils, IPython, comm) {
     "use strict";
     //--------------------------------------------------------------------
     // WidgetManager class
@@ -27,7 +26,7 @@ define([
         this._models = {}; /* Dictionary of model ids and model instance promises */
 
         // Register with the comm manager.
-        this.comm_manager.register_target(this.comm_target_name, $.proxy(this._handle_comm_open, this));
+        this.comm_manager.register_target(this.comm_target_name, _.bind(this._handle_comm_open, this));
 
         // Load the initial state of the widget manager if a load callback was
         // registered.
@@ -247,8 +246,8 @@ define([
             var handle_output = null;
             var handle_clear_output = null;
             if (cell.output_area) {
-                handle_output = $.proxy(cell.output_area.handle_output, cell.output_area);
-                handle_clear_output = $.proxy(cell.output_area.handle_clear_output, cell.output_area);
+                handle_output = _.bind(cell.output_area.handle_output, cell.output_area);
+                handle_clear_output = _.bind(cell.output_area.handle_clear_output, cell.output_area);
             }
 
             // Create callback dictionary using what is known
@@ -301,7 +300,7 @@ define([
          *      model_name: 'WidgetModel', 
          *      widget_class: 'jupyter_notebook.widgets.widget_int.IntSlider'})
          *      .then(function(model) { console.log('Create success!', model); },
-         *      $.proxy(console.error, console));
+         *      _.bind(console.error, console));
          *
          * Parameters
          * ----------

--- a/jupyter_notebook/static/widgets/js/widget.js
+++ b/jupyter_notebook/static/widgets/js/widget.js
@@ -432,7 +432,7 @@ define(["widgets/js/manager",
     widgetmanager.WidgetManager.register_widget_model('WidgetModel', WidgetModel);
 
 
-    var WidgetView = Backbone.View.extend({
+    var WidgetInterface = {
         initialize: function(parameters) {
             /**
              * Public constructor.
@@ -513,10 +513,9 @@ define(["widgets/js/manager",
             WidgetView.__super__.remove.apply(this, arguments);
             this.trigger('remove');
         }
-    });
+    };
 
-
-    var DOMWidgetView = WidgetView.extend({
+    var DOMWidgetInterface = {
         initialize: function (parameters) {
             /**
              * Public constructor
@@ -712,7 +711,7 @@ define(["widgets/js/manager",
         typeset: function(element, text){
             utils.typeset.apply(null, arguments);
         },
-    });
+    };
 
 
     var ViewList = function(create_view, remove_view, context) {
@@ -793,6 +792,9 @@ define(["widgets/js/manager",
             });
         },
     });
+
+    var WidgetView = Backbone.View.extend(WidgetInterface);
+    var DOMWidgetView = WidgetView.extend(DOMWidgetInterface);
 
     var widget = {
         'unpack_models': unpack_models,

--- a/jupyter_notebook/static/widgets/js/widget_box.js
+++ b/jupyter_notebook/static/widgets/js/widget_box.js
@@ -77,7 +77,7 @@ define([
                 warning: ['alert', 'alert-warning'],
                 danger: ['alert', 'alert-danger']
             };
-            this.update_mapped_classes(class_map, 'box_style', previous_trait_value, this.$box);
+            this.update_mapped_classes(class_map, 'box_style', previous_trait_value, this.$box[0]);
         },
         
         add_child_model: function(model) {

--- a/jupyter_notebook/static/widgets/js/widget_int.js
+++ b/jupyter_notebook/static/widgets/js/widget_int.js
@@ -461,7 +461,7 @@ define([
                 warning: ['progress-bar-warning'],
                 danger: ['progress-bar-danger']
             };
-            this.update_mapped_classes(class_map, 'bar_style', previous_trait_value, this.$bar);
+            this.update_mapped_classes(class_map, 'bar_style', previous_trait_value, this.$bar[0]);
         },
 
         update_attr: function(name, value) {

--- a/jupyter_notebook/static/widgets/js/widget_selection.js
+++ b/jupyter_notebook/static/widgets/js/widget_selection.js
@@ -113,8 +113,8 @@ define([
                 warning: ['btn-warning'],
                 danger: ['btn-danger']
             };
-            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$droplabel);
-            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$dropbutton);
+            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$droplabel[0]);
+            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$dropbutton[0]);
         },
 
         update_attr: function(name, value) {
@@ -411,7 +411,7 @@ define([
                 warning: ['btn-warning'],
                 danger: ['btn-danger']
             };
-            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$buttongroup.find('button'));
+            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$buttongroup.find('button')[0]);
         },
 
         handle_click: function (e) {


### PR DESCRIPTION
I would like to eventually allow users to write widgets using [backbone native views](https://github.com/akre54/Backbone.NativeView) or [d3 views](https://github.com/akre54/Backbone.D3View) or other drop-in replacements for `Backbone.View` using the DOM manipulation library of their choice.

These replacements for backbone views share the main `View.el` attribute, which is a native DOM element. Hence it should be used to insert the widget view in the page generically rather than `View.$el` which is specific to jquery.

Besides inserting the widget in the page, jquery is only used for some basic css styling and `$.proxy`.

In this PR, I Widget.js I removed the jquery dependency in manager.js, and Widget.js. 

In the very end, I do:
```JavaScript
var WidgetView = Backbone.View.extend(WidgetInterface);
var DOMWidgetView = WidgetView.extend(DOMWidgetInterface);
```
which I would like to move to a different file. The idea, is that anyone could define their own version of DOMWidgetView based on NativeView:
 
```JavaScript
var NativeWidgetView = Backbone.NativeView.extend(WidgetInterface);
var NativeDOMWidgetView = NativeWidgetView.extend(DOMWidgetInterface);
```