### PR TITLE
handle empty but defined SHELL env

### DIFF
--- a/jupyter_notebook/terminal/__init__.py
+++ b/jupyter_notebook/terminal/__init__.py
@@ -13,7 +13,7 @@ from .handlers import TerminalHandler, TermSocket
 from . import api_handlers
 
 def initialize(webapp):
-    shell = os.environ.get('SHELL', 'sh')
+    shell = os.environ.get('SHELL') or 'sh'
     terminal_manager = webapp.settings['terminal_manager'] = NamedTermManager(shell_command=[shell])
     terminal_manager.log = app_log
     base_url = webapp.settings['base_url']


### PR DESCRIPTION
Sometimes SHELL can be '', which should be treated the same as undefined.

closes #4