### PR TITLE
serve custom.js from JUPYTER_CONFIG_DIR/custom

### DIFF
--- a/jupyter_notebook/templates/page.html
+++ b/jupyter_notebook/templates/page.html
@@ -23,6 +23,7 @@
           {% endif %}
           baseUrl: '{{static_url("", include_version=False)}}',
           paths: {
+            custom : '{{ base_url }}custom',
             nbextensions : '{{ base_url }}nbextensions',
             kernelspecs : '{{ base_url }}kernelspecs',
             underscore : 'components/underscore/underscore-min',


### PR DESCRIPTION
served at /custom/ instead of /static/custom

keep serving ipython/profile/static/custom temporarily while we get the migration up