### PR TITLE
Add buffers argument to a widget custom message handler

### DIFF
--- a/jupyter_notebook/widgets/widget_string.py
+++ b/jupyter_notebook/widgets/widget_string.py
@@ -55,7 +55,7 @@ class Text(_String):
         self._submission_callbacks = CallbackDispatcher()
         self.on_msg(self._handle_string_msg)
 
-    def _handle_string_msg(self, _, content):
+    def _handle_string_msg(self, _, content, buffers):
         """Handle a msg from the front-end.
 
         Parameters


### PR DESCRIPTION
This change should have been made with the custom serialization changes a few weeks ago.  Thanks to @ssunkara1 for catching this.