### PR TITLE
Fix CSS of upload button for FF on Win7.

### DIFF
--- a/jupyter_notebook/static/tree/less/altuploadform.less
+++ b/jupyter_notebook/static/tree/less/altuploadform.less
@@ -13,6 +13,8 @@
 
     input.fileinput
     {
+        text-align: center;
+        vertical-align: middle;
         display: inline;
         opacity: 0;
         z-index: 2;


### PR DESCRIPTION
Before, left is Chrome right is Firefox:
![bug](https://cloud.githubusercontent.com/assets/3292874/7206933/a2f73d5e-e4ea-11e4-9e25-500f4f6d772f.PNG)

After:
![fix](https://cloud.githubusercontent.com/assets/3292874/7206937/aa3eebb6-e4ea-11e4-8d73-d45fed569473.PNG)
