### PR TITLE
Use name ignored by dropbox for atomic saving temp files

### DIFF
--- a/jupyter_notebook/services/contents/fileio.py
+++ b/jupyter_notebook/services/contents/fileio.py
@@ -99,7 +99,7 @@ def atomic_writing(path, text=True, encoding='utf-8', **kwargs):
             # Set file permissions from default umask
             mask = os.umask(0)
             os.umask(mask)  # Set it back... strange API
-            mode = (0o777 & ~mask)
+            mode = (0o666 & ~mask)
             os.chmod(tmp_path, mode)
         # Ignore any other failures to copy metadata
 


### PR DESCRIPTION
See discussion on ipython/ipython#8322

By using a '.~' prefix for the temporary files, Dropbox should ignore them, which makes atomic saving a bit less inconvenient.

However, to do this, we need to switch back from using temporary directories (implemented in ipython/ipython#7469). This uses the other approach described in ipython/ipython#7317 instead.