### PR TITLE
allow OPTIONS requests for api endpoints (to enable CORS)

### DIFF
--- a/jupyter_notebook/services/kernels/handlers.py
+++ b/jupyter_notebook/services/kernels/handlers.py
@@ -48,7 +48,7 @@ class MainKernelHandler(IPythonHandler):
 
 class KernelHandler(IPythonHandler):
 
-    SUPPORTED_METHODS = ('DELETE', 'GET')
+    SUPPORTED_METHODS = ('DELETE', 'GET', 'OPTIONS')
 
     @web.authenticated
     @json_errors
@@ -66,6 +66,12 @@ class KernelHandler(IPythonHandler):
         self.set_status(204)
         self.finish()
 
+    @web.authenticated
+    @json_errors
+    def options(self, kernel_id):
+        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
+        self.finish()
+
 
 class KernelActionHandler(IPythonHandler):
 
@@ -81,6 +87,12 @@ class KernelActionHandler(IPythonHandler):
             model = km.kernel_model(kernel_id)
             self.set_header('Location', '{0}api/kernels/{1}'.format(self.base_url, kernel_id))
             self.write(json.dumps(model))
+        self.finish()
+
+    @web.authenticated
+    @json_errors
+    def options(self, kernel_id, action):
+        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
         self.finish()
 
 

--- a/jupyter_notebook/services/kernelspecs/handlers.py
+++ b/jupyter_notebook/services/kernelspecs/handlers.py
@@ -41,7 +41,7 @@ def kernelspec_model(handler, name):
     return d
 
 class MainKernelSpecHandler(IPythonHandler):
-    SUPPORTED_METHODS = ('GET',)
+    SUPPORTED_METHODS = ('GET', 'OPTIONS')
 
     @web.authenticated
     @json_errors
@@ -60,6 +60,11 @@ class MainKernelSpecHandler(IPythonHandler):
             specs[kernel_name] = d
         self.set_header("Content-Type", 'application/json')
         self.finish(json.dumps(model))
+
+    @web.authenticated
+    @json_errors
+    def options(self):
+        self.finish()
 
 
 class KernelSpecHandler(IPythonHandler):

--- a/jupyter_notebook/services/sessions/handlers.py
+++ b/jupyter_notebook/services/sessions/handlers.py
@@ -65,6 +65,12 @@ class SessionRootHandler(IPythonHandler):
         self.set_status(201)
         self.finish(json.dumps(model, default=date_default))
 
+    @web.authenticated
+    @json_errors
+    def options(self):
+        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
+        self.finish()
+
 class SessionHandler(IPythonHandler):
 
     SUPPORTED_METHODS = ('GET', 'PATCH', 'DELETE')


### PR DESCRIPTION
Although `NotebookApp.allow_hosts` was set correctly, the api endpoints were disallowing `OPTIONS` requests, and so the browser refused to allow my web page to access ipython's endpoints.

These changes add `OPTIONS` handlers.

I didn't see an obvious place to add tests for this -- the `services.js` test is run in casper, and so is run from the same origin.