### PR TITLE
Fix print preview in Firefox

### DIFF
--- a/jupyter_notebook/static/notebook/less/notebook.less
+++ b/jupyter_notebook/static/notebook/less/notebook.less
@@ -39,6 +39,9 @@ div#notebook_panel {
         min-height: @page-min-height;
         .box-shadow(@global-shadow);
     }
+    @media print {
+        width: 100%;
+    }
 }
 
 div.ui-widget-content {


### PR DESCRIPTION
Long story short, the print preview has been broken in Firefox for a while. In master:

![screenshot from 2015-04-28 21 51 35](https://cloud.githubusercontent.com/assets/599274/7385156/ebe15922-ee05-11e4-8862-50b93110f7b0.png)

We didn't notice because if you add enough cells, the bug doesn't occur.

When I was trying to reproduce this bug after the [sticky header](https://github.com/ipython/ipython/pull/7997) PR, I noticed that it was not Firefox that was causing the bug. It is the grid that is being applied in some media queries. However, it is easy to avoid that issue with `width: 100%;` in the notebook container. After this simple fix the issue is resolved:

![screenshot from 2015-04-29 00 32 42](https://cloud.githubusercontent.com/assets/599274/7385243/4b424b50-ee07-11e4-8205-735c7c7c53a2.png)

@minrk If this was the main issue with the sticky header PR, you might want to give it a second look. I solved the performance issue a few weeks ago and the print preview was the only thing left to be fixed. [This](https://github.com/rsmith31415/ipython/commits/add-sticky-header) is the repository with the changes.