### PR TITLE
Wrap potentially native element into a jquery selection

### DIFF
--- a/jupyter_notebook/static/notebook/js/keyboardmanager.js
+++ b/jupyter_notebook/static/notebook/js/keyboardmanager.js
@@ -188,6 +188,7 @@ define([
     };
 
     KeyboardManager.prototype.register_events = function (e) {
+        e = $(e);
         var that = this;
         var handle_focus = function () {
             that.disable();


### PR DESCRIPTION
This is wrapping the passed argument into a JQuery selection. This is for https://github.com/ipython/ipython_widgets/pull/6 (to remove the assumption of jquery backbone views in IPython widgets.)